### PR TITLE
Reset class variable "heading" after calibration process.

### DIFF
--- a/SpherlyServer/src/Sphero.java
+++ b/SpherlyServer/src/Sphero.java
@@ -122,6 +122,7 @@ public class Sphero {
     }
 
     public void resetHeading(){
+        heading = 0;
         setHeading(0);
     }
 
@@ -191,7 +192,7 @@ public class Sphero {
         comm.write(packet);
     }
 
-    public void calibrate(boolean flagOn){
+    public void calibrate(boolean flagOn) {
         if (flagOn) {
             // enter in the calibration process
             setRGB(0, 0, 0);


### PR DESCRIPTION
When the calibration is done, we have to reset the "heading" to zero. 
We have a class variable named "heading". This variable must be set to 0 otherwise a wrong value will be used. Have a look on "rollForward" that use his class variable.
